### PR TITLE
Integrate chat persistence across stack

### DIFF
--- a/Frontend/client/components/regnav/ChatHistory.tsx
+++ b/Frontend/client/components/regnav/ChatHistory.tsx
@@ -1,60 +1,56 @@
-import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { ChatSessionSummary } from "@shared/api";
 
-export function ChatHistory({ onSelect }: { onSelect?: (s: any) => void }) {
-  const [sessions, setSessions] = useState(() => {
-    try {
-      return JSON.parse(localStorage.getItem("regnav:sessions") || "[]");
-    } catch {
-      return [];
-    }
-  });
+interface ChatHistoryProps {
+  sessions: ChatSessionSummary[];
+  loading?: boolean;
+  onSelect?: (sessionId: string | null) => void;
+  onDelete?: (sessionId: string) => void;
+}
 
-  useEffect(() => {
-    const handler = () => {
-      try {
-        setSessions(JSON.parse(localStorage.getItem("regnav:sessions") || "[]"));
-      } catch {
-        setSessions([]);
-      }
-    };
-    window.addEventListener("regnav:sessions:updated", handler as EventListener);
-    return () => window.removeEventListener("regnav:sessions:updated", handler as EventListener);
-  }, []);
-
-  const newChat = () => {
-    if (onSelect) onSelect(null);
+export function ChatHistory({ sessions, loading, onSelect, onDelete }: ChatHistoryProps) {
+  const startNewChat = () => {
+    onSelect?.(null);
     window.scrollTo({ top: 0, behavior: "smooth" });
-  };
-
-  const remove = (id: string) => {
-    const updated = sessions.filter((s: any) => s.id !== id);
-    setSessions(updated);
-    localStorage.setItem("regnav:sessions", JSON.stringify(updated));
-    window.dispatchEvent(new CustomEvent("regnav:sessions:updated"));
   };
 
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <div className="text-sm font-medium">Recent conversations</div>
-        <Button variant="outline" size="sm" onClick={newChat}>New chat</Button>
+        <Button variant="outline" size="sm" onClick={startNewChat}>
+          New chat
+        </Button>
       </div>
 
       <div className="divide-y">
-        {sessions.length === 0 ? (
-          <div className="py-3 text-sm text-muted-foreground">No saved chats yet. Start a new conversation and save it.</div>
+        {loading ? (
+          <div className="py-3 text-sm text-muted-foreground">Loading sessions…</div>
+        ) : sessions.length === 0 ? (
+          <div className="py-3 text-sm text-muted-foreground">
+            No saved chats yet. Start a new conversation to begin tracking history.
+          </div>
         ) : (
-          sessions.map((s: any) => (
+          sessions.map((s) => (
             <div key={s.id} className="py-3">
               <div className="flex items-center justify-between">
-                <div className="cursor-pointer" onClick={() => onSelect && onSelect(s)}>
+                <button
+                  type="button"
+                  className="text-left"
+                  onClick={() => onSelect?.(s.id)}
+                >
                   <div className="font-semibold">{s.title}</div>
-                  <div className="text-xs text-muted-foreground">{s.snippet}</div>
-                </div>
+                  {s.snippet && <div className="text-xs text-muted-foreground">{s.snippet}</div>}
+                  <div className="text-xs text-muted-foreground">{new Date(s.updatedAt).toLocaleString()}</div>
+                </button>
                 <div className="flex items-center gap-2">
-                  <div className="text-xs text-muted-foreground">{new Date(s.time).toLocaleString()}</div>
-                  <Button variant="ghost" size="sm" onClick={() => remove(s.id)}>Delete</Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onDelete?.(s.id)}
+                  >
+                    Delete
+                  </Button>
                 </div>
               </div>
             </div>

--- a/Frontend/client/components/regnav/ChatPanel.tsx
+++ b/Frontend/client/components/regnav/ChatPanel.tsx
@@ -2,27 +2,32 @@ import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { MessageBubble } from "./MessageBubble";
-import { ScoredDoc, SearchFilters, SearchRequest, SearchResponse } from "@shared/api";
+import { ChatAskRequest, ChatAskResponse, ChatMessage, ChatSessionDetail, ChatCitation, SearchFilters } from "@shared/api";
 import { Loader2, Send, Save } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 
-interface Message {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  citations?: ScoredDoc[];
-}
-
-export function ChatPanel({ filters, initialMessages }: { filters: SearchFilters; initialMessages?: Message[] }) {
-  const welcome: Message = {
+const WELCOME: ChatMessage = {
     id: "welcome",
     role: "assistant",
     content: "Ask about Maryland Department of Agriculture/Environment regulations. Use the filters to target jurisdiction, agency, or year.",
+    createdAt: new Date().toISOString(),
   };
 
-  const [messages, setMessages] = useState<Message[]>(initialMessages && initialMessages.length > 0 ? initialMessages : [welcome]);
+interface ChatPanelProps {
+  filters: SearchFilters;
+  userId: string;
+  session?: ChatSessionDetail | null;
+  loading?: boolean;
+  onSessionCreated?: (sessionId: string) => void;
+  onSessionUpdated?: (sessionId: string) => Promise<void> | void;
+  onResetSession?: () => void;
+}
+
+export function ChatPanel({ filters, userId, session, loading: sessionLoading, onSessionCreated, onSessionUpdated, onResetSession }: ChatPanelProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>(session?.messages?.length ? session.messages : [WELCOME]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(session?.id ?? null);
   const endRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -30,40 +35,85 @@ export function ChatPanel({ filters, initialMessages }: { filters: SearchFilters
   }, [messages]);
 
   useEffect(() => {
-    if (initialMessages) setMessages(initialMessages);
-  }, [initialMessages]);
+    if (session?.messages?.length) {
+      setMessages(session.messages);
+    } else {
+      setMessages([WELCOME]);
+    }
+    setActiveSessionId(session?.id ?? null);
+  }, [session?.id, session?.messages]);
 
   const send = async () => {
     const q = input.trim();
-    if (!q || loading) return;
+    if (!q || loading || sessionLoading || !userId) return;
     setInput("");
-    const userMsg: Message = { id: crypto.randomUUID(), role: "user", content: q };
-    setMessages((m) => [...m, userMsg]);
+    const placeholderId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const placeholder: ChatMessage = { id: placeholderId, role: "user", content: q, createdAt: now };
+    setMessages((m) => [...m, placeholder]);
     setLoading(true);
     try {
-      const payload: SearchRequest = { query: q, filters, topK: 4 };
+      const payload: ChatAskRequest = {
+        question: q,
+        filters,
+        topK: 4,
+        sessionId: activeSessionId ?? undefined,
+        sessionTitle: session?.title ?? q.slice(0, 60),
+      };
       const res = await fetch("/api/search", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-User-Id": userId },
         body: JSON.stringify(payload),
       });
-      const data = (await res.json()) as SearchResponse;
-      const assistantMsg: Message = {
-        id: crypto.randomUUID(),
-        role: "assistant",
-        content: data.answer,
-        citations: data.hits,
+
+      let parsed: unknown = null;
+      try {
+        parsed = await res.json();
+      } catch {
+        // Ignore JSON parsing errors so we can surface a clearer toast message below.
+      }
+
+      if (!res.ok) {
+        const errorMessage =
+          (parsed && typeof parsed === "object" && "error" in parsed && typeof (parsed as any).error === "string"
+            ? (parsed as any).error
+            : undefined) ??
+          `Request failed with status ${res.status}`;
+        throw new Error(errorMessage);
+      }
+
+      if (!parsed || typeof parsed !== "object" || !("sessionId" in parsed)) {
+        throw new Error("Malformed response from server");
+      }
+
+      const data = parsed as ChatAskResponse;
+      const updatedSessionId = data.sessionId;
+      const assistantCitations: ChatCitation[] = data.sources ?? [];
+      const userMessage = data.userMessage;
+      const assistantMessage: ChatMessage = {
+        ...data.assistantMessage,
+        citations: assistantCitations,
       };
-      window.dispatchEvent(new CustomEvent("regnav:citations", { detail: data.hits }));
-      setMessages((m) => [...m, assistantMsg]);
+      setMessages((m) => {
+        const withoutPlaceholder = m.filter((msg) => msg.id !== placeholderId);
+        return [...withoutPlaceholder, userMessage, assistantMessage];
+      });
+      setActiveSessionId(updatedSessionId);
+      window.dispatchEvent(new CustomEvent("regnav:citations", { detail: assistantCitations }));
+      if (!session?.id && !activeSessionId) {
+        onSessionCreated?.(updatedSessionId);
+      }
+      await onSessionUpdated?.(updatedSessionId);
     } catch (e) {
-      const err: Message = {
+      const description = e instanceof Error ? e.message : "Could not run the query. Try again.";
+      const err: ChatMessage = {
         id: crypto.randomUUID(),
         role: "assistant",
         content: "There was an error processing your query.",
+        createdAt: new Date().toISOString(),
       };
-      setMessages((m) => [...m, err]);
-      toast({ title: "Search error", description: "Could not run the query. Try again." });
+      setMessages((m) => m.filter((msg) => msg.id !== placeholderId).concat(err));
+      toast({ title: "Search error", description });
     } finally {
       setLoading(false);
     }
@@ -76,24 +126,39 @@ export function ChatPanel({ filters, initialMessages }: { filters: SearchFilters
     }
   };
 
-  const saveSession = () => {
-    const title = window.prompt("Save chat as", "New chat");
+  const renameSession = async () => {
+    if (!activeSessionId || !userId) {
+      toast({ title: "No session", description: "Send a message before saving the chat." });
+      return;
+    }
+    const title = window.prompt("Save chat as", session?.title ?? "New chat");
     if (!title) return;
-
     try {
-      const sessions = JSON.parse(localStorage.getItem("regnav:sessions") || "[]");
-      const snippet = messages.find((m) => m.role === "assistant")?.content.slice(0, 120) || messages[0]?.content.slice(0, 120) || "";
-      const session = { id: crypto.randomUUID(), title, snippet, time: new Date().toISOString(), messages };
-      sessions.unshift(session);
-      localStorage.setItem("regnav:sessions", JSON.stringify(sessions));
-      window.dispatchEvent(new CustomEvent("regnav:sessions:updated"));
-      toast({ title: "Saved", description: "Chat saved to history." });
-    } catch {
-      toast({ title: "Error", description: "Could not save chat." });
+      const res = await fetch(`/api/chat/sessions/${encodeURIComponent(activeSessionId)}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-User-Id": userId,
+        },
+        body: JSON.stringify({ title }),
+      });
+      if (!res.ok) {
+        const { error } = (await res.json()) as { error?: string };
+        throw new Error(error ?? `Rename failed (${res.status})`);
+      }
+      toast({ title: "Saved", description: "Chat title updated." });
+      await onSessionUpdated?.(activeSessionId);
+    } catch (error) {
+      const description = error instanceof Error ? error.message : "Could not rename chat.";
+      toast({ title: "Error", description });
     }
   };
 
-  const newChat = () => setMessages([welcome]);
+  const newChat = () => {
+    setMessages([WELCOME]);
+    setActiveSessionId(null);
+    onResetSession?.();
+  };
 
   return (
     <div className="flex h-full flex-col">
@@ -103,13 +168,19 @@ export function ChatPanel({ filters, initialMessages }: { filters: SearchFilters
           <div className="text-xs text-muted-foreground">Interactive regulatory QA</div>
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="ghost" onClick={newChat} size="sm">New</Button>
-          <Button variant="outline" onClick={saveSession} size="sm"><Save className="h-4 w-4" /></Button>
+          <Button variant="ghost" onClick={newChat} size="sm" disabled={loading || sessionLoading}>
+            New
+          </Button>
+          <Button variant="outline" onClick={renameSession} size="sm" disabled={loading || sessionLoading}>
+            <Save className="h-4 w-4" />
+          </Button>
         </div>
       </div>
 
       <div className="flex-1 space-y-4 overflow-y-auto p-4 pr-2">
-        {messages.map((m) => (
+        {(sessionLoading ? [
+          { id: "loading", role: "assistant", content: "Loading session…", createdAt: new Date().toISOString() },
+        ] : messages).map((m) => (
           <div key={m.id} className="space-y-2">
             <MessageBubble role={m.role}>{m.content}</MessageBubble>
             {m.citations && m.citations.length > 0 && (
@@ -117,7 +188,7 @@ export function ChatPanel({ filters, initialMessages }: { filters: SearchFilters
                 <div className="font-semibold">Citations:</div>
                 <ul className="list-disc list-inside">
                   {m.citations.map((c) => (
-                    <li key={c.meta.id}>{c.meta.title ?? c.meta.id}</li>
+                    <li key={c.id}>{c.label}</li>
                   ))}
                 </ul>
               </div>
@@ -137,7 +208,7 @@ export function ChatPanel({ filters, initialMessages }: { filters: SearchFilters
             className="w-full"
           />
         </div>
-        <Button onClick={send} disabled={loading || !input.trim()}>
+        <Button onClick={send} disabled={loading || sessionLoading || !input.trim() || !userId}>
           {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
           <span className="ml-2 hidden sm:inline">Send</span>
         </Button>

--- a/Frontend/client/components/regnav/SourceCard.tsx
+++ b/Frontend/client/components/regnav/SourceCard.tsx
@@ -1,28 +1,26 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ExternalLink } from "lucide-react";
-import { ScoredDoc } from "@shared/api";
+import { ChatCitation } from "@shared/api";
 
-export function SourceCard({ hit }: { hit: ScoredDoc }) {
+export function SourceCard({ hit }: { hit: ChatCitation }) {
   return (
     <Card className="overflow-hidden">
       <CardHeader className="space-y-1 pb-2">
         <CardTitle className="text-sm font-semibold leading-snug">
-          {hit.meta.title}
+          {hit.docTitle ?? hit.label}
         </CardTitle>
         <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-          <Badge variant="secondary">{hit.meta.agency}</Badge>
-          <Badge variant="outline">{hit.meta.jurisdiction}</Badge>
-          <Badge variant="outline">{hit.meta.year}</Badge>
-          <span className="ml-auto text-[10px]">Score: {hit.score.toFixed(2)}</span>
+          {hit.comarDisplay && <Badge variant="secondary">{hit.comarDisplay}</Badge>}
+          {hit.pages && <Badge variant="outline">Pages {hit.pages}</Badge>}
         </div>
       </CardHeader>
       <CardContent>
-        <p className="line-clamp-4 text-xs leading-relaxed">{hit.snippet.text}</p>
-        {hit.meta.sourceUrl && (
+        {hit.snippet && <p className="line-clamp-4 text-xs leading-relaxed">{hit.snippet}</p>}
+        {hit.url && (
           <a
             className="mt-2 inline-flex items-center gap-1 text-xs text-primary hover:underline"
-            href={hit.meta.sourceUrl}
+            href={hit.url}
             target="_blank"
             rel="noreferrer"
           >

--- a/Frontend/client/components/regnav/SourcesPanel.tsx
+++ b/Frontend/client/components/regnav/SourcesPanel.tsx
@@ -1,8 +1,8 @@
-import { ScoredDoc } from "@shared/api";
+import { ChatCitation } from "@shared/api";
 import { SourceCard } from "./SourceCard";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
-export function SourcesPanel({ latestHits }: { latestHits: ScoredDoc[] }) {
+export function SourcesPanel({ latestHits }: { latestHits: ChatCitation[] }) {
   return (
     <div className="w-full">
       <div className="mt-0">
@@ -14,7 +14,7 @@ export function SourcesPanel({ latestHits }: { latestHits: ScoredDoc[] }) {
             {latestHits.length === 0 ? (
               <p className="text-sm text-muted-foreground">Run a query to see top-matching sources.</p>
             ) : (
-              latestHits.map((h) => <SourceCard key={h.meta.id} hit={h} />)
+              latestHits.map((h) => <SourceCard key={h.id} hit={h} />)
             )}
           </TabsContent>
         </Tabs>

--- a/Frontend/client/lib/searchFilters.ts
+++ b/Frontend/client/lib/searchFilters.ts
@@ -1,0 +1,9 @@
+import { SearchFilters } from "@shared/api";
+
+export const DEFAULT_SEARCH_FILTERS: SearchFilters = {
+  jurisdiction: "Maryland",
+};
+
+export const createDefaultSearchFilters = (): SearchFilters => ({
+  ...DEFAULT_SEARCH_FILTERS,
+});

--- a/Frontend/client/lib/user.ts
+++ b/Frontend/client/lib/user.ts
@@ -1,0 +1,14 @@
+const USER_KEY = "regnav:userId";
+
+export function ensureUserId(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  const existing = window.localStorage.getItem(USER_KEY);
+  if (existing) {
+    return existing;
+  }
+  const id = crypto.randomUUID();
+  window.localStorage.setItem(USER_KEY, id);
+  return id;
+}

--- a/Frontend/client/pages/Admin.tsx
+++ b/Frontend/client/pages/Admin.tsx
@@ -1,48 +1,122 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { SiteHeader } from "@/components/layout/SiteHeader";
 import { SiteFooter } from "@/components/layout/SiteFooter";
 import { MessageBubble } from "@/components/regnav/MessageBubble";
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
+import { ChatMemory, ChatSessionDetail, ChatSessionSummary } from "@shared/api";
+import { ensureUserId } from "@/lib/user";
+import { toast } from "@/hooks/use-toast";
 
 export default function Admin() {
-  const [sessions, setSessions] = useState<any[]>([]);
-  const [selected, setSelected] = useState<any | null>(null);
+  const [userId, setUserId] = useState<string>("");
+  const [sessions, setSessions] = useState<ChatSessionSummary[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [selected, setSelected] = useState<ChatSessionDetail | null>(null);
+  const [memories, setMemories] = useState<ChatMemory[]>([]);
+  const [memoriesLoading, setMemoriesLoading] = useState(false);
+  const [newMemory, setNewMemory] = useState("");
   const navigate = useNavigate();
 
-  useEffect(() => {
+  const headers = useMemo(() => ({ "X-User-Id": userId, "Content-Type": "application/json" }), [userId]);
+
+  const loadSessions = useCallback(async () => {
+    if (!userId) return;
+    setSessionsLoading(true);
     try {
-      const s = JSON.parse(localStorage.getItem("regnav:sessions") || "[]");
-      setSessions(s);
-    } catch {
-      setSessions([]);
+      const res = await fetch("/api/chat/sessions", { headers });
+      const payload = (await res.json()) as { sessions: ChatSessionSummary[]; error?: string };
+      if (!res.ok) throw new Error(payload.error ?? `Failed to load sessions (${res.status})`);
+      setSessions(payload.sessions ?? []);
+    } catch (error) {
+      const description = error instanceof Error ? error.message : "Could not load sessions.";
+      toast({ title: "Error", description });
+    } finally {
+      setSessionsLoading(false);
     }
+  }, [headers, userId]);
+
+  const loadSessionDetail = useCallback(
+    async (sessionId: string) => {
+      if (!userId) return;
+      try {
+        const res = await fetch(`/api/chat/sessions/${encodeURIComponent(sessionId)}`, { headers });
+        const payload = (await res.json()) as { session: ChatSessionDetail; error?: string };
+        if (!res.ok) throw new Error(payload.error ?? `Failed to load session (${res.status})`);
+        setSelected(payload.session);
+      } catch (error) {
+        const description = error instanceof Error ? error.message : "Could not load session.";
+        toast({ title: "Error", description });
+        setSelected(null);
+      }
+    },
+    [headers, userId],
+  );
+
+  const loadMemories = useCallback(async () => {
+    if (!userId) return;
+    setMemoriesLoading(true);
+    try {
+      const res = await fetch("/api/chat/memories", { headers });
+      const payload = (await res.json()) as { memories: ChatMemory[]; error?: string };
+      if (!res.ok) throw new Error(payload.error ?? `Failed to load memories (${res.status})`);
+      setMemories(payload.memories ?? []);
+    } catch (error) {
+      const description = error instanceof Error ? error.message : "Could not load memories.";
+      toast({ title: "Error", description });
+    } finally {
+      setMemoriesLoading(false);
+    }
+  }, [headers, userId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const id = ensureUserId();
+    setUserId(id);
   }, []);
 
-  const refresh = () => {
-    try {
-      const s = JSON.parse(localStorage.getItem("regnav:sessions") || "[]");
-      setSessions(s);
-    } catch {
-      setSessions([]);
+  useEffect(() => {
+    if (!userId) return;
+    void loadSessions();
+    void loadMemories();
+  }, [loadMemories, loadSessions, userId]);
+
+  const refresh = useCallback(() => {
+    void loadSessions();
+    void loadMemories();
+  }, [loadMemories, loadSessions]);
+
+  const remove = useCallback(
+    async (id: string) => {
+      try {
+        const res = await fetch(`/api/chat/sessions/${encodeURIComponent(id)}`, {
+          method: "DELETE",
+          headers,
+        });
+        if (!res.ok) {
+          const payload = (await res.json()) as { error?: string };
+          throw new Error(payload.error ?? `Failed to delete session (${res.status})`);
+        }
+        if (selected?.id === id) setSelected(null);
+        toast({ title: "Deleted", description: "Session removed." });
+        await loadSessions();
+      } catch (error) {
+        const description = error instanceof Error ? error.message : "Could not delete session.";
+        toast({ title: "Error", description });
+      }
+    },
+    [headers, loadSessions, selected?.id],
+  );
+
+  const clearAll = useCallback(async () => {
+    for (const session of sessions) {
+      await remove(session.id);
     }
-  };
-
-  const remove = (id: string) => {
-    const updated = sessions.filter((s) => s.id !== id);
-    localStorage.setItem("regnav:sessions", JSON.stringify(updated));
     setSelected(null);
-    setSessions(updated);
-  };
-
-  const clearAll = () => {
-    localStorage.removeItem("regnav:sessions");
-    setSessions([]);
-    setSelected(null);
-  };
+  }, [remove, sessions]);
 
   const exportAll = () => {
-    const blob = new Blob([JSON.stringify(sessions, null, 2)], { type: "application/json" });
+    const blob = new Blob([JSON.stringify({ sessions, memories }, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -53,6 +127,51 @@ export default function Admin() {
 
   const openInChat = (id: string) => {
     navigate(`/chat?session=${encodeURIComponent(id)}`);
+  };
+
+  const addNewMemory = useCallback(async () => {
+    const content = newMemory.trim();
+    if (!content) return;
+    try {
+      const res = await fetch("/api/chat/memories", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ content }),
+      });
+      const payload = (await res.json()) as { memory: ChatMemory; error?: string };
+      if (!res.ok) throw new Error(payload.error ?? `Failed to add memory (${res.status})`);
+      setNewMemory("");
+      toast({ title: "Saved", description: "Memory added." });
+      await loadMemories();
+    } catch (error) {
+      const description = error instanceof Error ? error.message : "Could not add memory.";
+      toast({ title: "Error", description });
+    }
+  }, [headers, loadMemories, newMemory]);
+
+  const removeMemory = useCallback(
+    async (id: string) => {
+      try {
+        const res = await fetch(`/api/chat/memories/${encodeURIComponent(id)}`, {
+          method: "DELETE",
+          headers,
+        });
+        if (!res.ok) {
+          const payload = (await res.json()) as { error?: string };
+          throw new Error(payload.error ?? `Failed to delete memory (${res.status})`);
+        }
+        toast({ title: "Deleted", description: "Memory removed." });
+        await loadMemories();
+      } catch (error) {
+        const description = error instanceof Error ? error.message : "Could not delete memory.";
+        toast({ title: "Error", description });
+      }
+    },
+    [headers, loadMemories],
+  );
+
+  const handleSessionSelect = (sessionId: string) => {
+    void loadSessionDetail(sessionId);
   };
 
   return (
@@ -72,18 +191,20 @@ export default function Admin() {
                 </div>
               </div>
 
-              {sessions.length === 0 ? (
+              {sessionsLoading ? (
+                <div className="text-sm text-muted-foreground">Loading sessions…</div>
+              ) : sessions.length === 0 ? (
                 <div className="text-sm text-muted-foreground">No sessions found.</div>
               ) : (
                 <div className="divide-y">
                   {sessions.map((s) => (
                     <div key={s.id} className="py-3 flex items-start justify-between">
-                      <div className="cursor-pointer" onClick={() => setSelected(s)}>
+                      <div className="cursor-pointer" onClick={() => handleSessionSelect(s.id)}>
                         <div className="font-semibold">{s.title}</div>
-                        <div className="text-xs text-muted-foreground">{s.snippet}</div>
+                        {s.snippet && <div className="text-xs text-muted-foreground">{s.snippet}</div>}
+                        <div className="text-xs text-muted-foreground">{new Date(s.updatedAt).toLocaleString()}</div>
                       </div>
                       <div className="flex flex-col items-end gap-2">
-                        <div className="text-xs text-muted-foreground">{new Date(s.time).toLocaleString()}</div>
                         <div className="flex gap-2">
                           <Button size="sm" variant="ghost" onClick={() => openInChat(s.id)}>Open</Button>
                           <Button size="sm" variant="outline" onClick={() => remove(s.id)}>Delete</Button>
@@ -106,7 +227,7 @@ export default function Admin() {
                   <div className="flex items-center justify-between">
                     <div>
                       <div className="font-semibold">{selected.title}</div>
-                      <div className="text-xs text-muted-foreground">{new Date(selected.time).toLocaleString()}</div>
+                      <div className="text-xs text-muted-foreground">{new Date(selected.updatedAt).toLocaleString()}</div>
                     </div>
                     <div className="flex gap-2">
                       <Button onClick={() => openInChat(selected.id)}>Open in Chat</Button>
@@ -115,12 +236,58 @@ export default function Admin() {
                   </div>
 
                   <div className="space-y-3">
-                    {selected.messages.map((m: any) => (
+                    {selected.messages.map((m) => (
                       <div key={m.id}>
                         <MessageBubble role={m.role}>{m.content}</MessageBubble>
                       </div>
                     ))}
                   </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="md:col-span-4">
+            <div className="rounded-2xl border bg-card p-4 space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold">User memory</h2>
+                <Button variant="outline" size="sm" onClick={loadMemories}>
+                  Refresh
+                </Button>
+              </div>
+
+              <div className="space-y-3">
+                <textarea
+                  className="w-full rounded-md border bg-background p-2 text-sm"
+                  rows={3}
+                  placeholder="Add a new memory about the user…"
+                  value={newMemory}
+                  onChange={(e) => setNewMemory(e.target.value)}
+                />
+                <Button onClick={addNewMemory} disabled={!newMemory.trim()}>
+                  Save memory
+                </Button>
+              </div>
+
+              {memoriesLoading ? (
+                <div className="text-sm text-muted-foreground">Loading memories…</div>
+              ) : memories.length === 0 ? (
+                <div className="text-sm text-muted-foreground">No persistent memories captured yet.</div>
+              ) : (
+                <div className="space-y-3">
+                  {memories.map((memory) => (
+                    <div key={memory.id} className="rounded-md border p-3 text-sm">
+                      <div className="flex items-start justify-between gap-2">
+                        <div>
+                          <div>{memory.content}</div>
+                          <div className="text-xs text-muted-foreground">Updated {new Date(memory.updatedAt).toLocaleString()}</div>
+                        </div>
+                        <Button variant="ghost" size="sm" onClick={() => removeMemory(memory.id)}>
+                          Delete
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
                 </div>
               )}
             </div>

--- a/Frontend/client/pages/Chat.tsx
+++ b/Frontend/client/pages/Chat.tsx
@@ -1,29 +1,145 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { SiteHeader } from "@/components/layout/SiteHeader";
 import { SiteFooter } from "@/components/layout/SiteFooter";
 import { ChatPanel } from "@/components/regnav/ChatPanel";
 import { ChatHistory } from "@/components/regnav/ChatHistory";
-import { SearchFilters } from "@shared/api";
+import { FiltersPanel } from "@/components/regnav/FiltersPanel";
+import { ChatSessionDetail, ChatSessionSummary, SearchFilters } from "@shared/api";
+import { createDefaultSearchFilters } from "@/lib/searchFilters";
+import { ensureUserId } from "@/lib/user";
+import { toast } from "@/hooks/use-toast";
 
 export default function Chat() {
-  const [selected, setSelected] = useState<any | null>(null);
-  const [filters] = useState<SearchFilters>({ jurisdiction: "Maryland" });
+  const [userId, setUserId] = useState<string>("");
+  const [sessions, setSessions] = useState<ChatSessionSummary[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [selectedSession, setSelectedSession] = useState<ChatSessionDetail | null>(null);
+  const [chatLoading, setChatLoading] = useState(false);
+  const [filters, setFilters] = useState<SearchFilters>(() => createDefaultSearchFilters());
   const location = useLocation();
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
+    setUserId(ensureUserId());
+  }, []);
+
+  const headers = useMemo(() => ({ "X-User-Id": userId, "Content-Type": "application/json" }), [userId]);
+
+  const loadSessions = useCallback(async () => {
+    if (!userId) return;
+    setSessionsLoading(true);
+    try {
+      const res = await fetch("/api/chat/sessions", { headers });
+      if (!res.ok) {
+        throw new Error(`Failed to load sessions (${res.status})`);
+      }
+      const data = (await res.json()) as { sessions: ChatSessionSummary[] };
+      setSessions(data.sessions ?? []);
+    } catch (error) {
+      const description = error instanceof Error ? error.message : "Could not load chat sessions.";
+      toast({ title: "Error", description });
+    } finally {
+      setSessionsLoading(false);
+    }
+  }, [headers, userId]);
+
+  const loadSessionDetail = useCallback(
+    async (sessionId: string | null) => {
+      if (!sessionId) {
+        setSelectedSession(null);
+        return;
+      }
+      setChatLoading(true);
+      try {
+        const res = await fetch(`/api/chat/sessions/${encodeURIComponent(sessionId)}`, { headers });
+        const payload = (await res.json()) as { session: ChatSessionDetail; error?: string };
+        if (!res.ok) {
+          throw new Error(payload.error ?? `Failed to load session (${res.status})`);
+        }
+        setSelectedSession(payload.session);
+      } catch (error) {
+        const description = error instanceof Error ? error.message : "Could not load session.";
+        toast({ title: "Error", description });
+        setSelectedSession(null);
+      } finally {
+        setChatLoading(false);
+      }
+    },
+    [headers],
+  );
+
+  useEffect(() => {
+    if (!userId) return;
+    void loadSessions();
+  }, [userId, loadSessions]);
+
+  useEffect(() => {
+    if (!userId) return;
     const params = new URLSearchParams(location.search);
     const sessionId = params.get("session");
     if (sessionId) {
-      try {
-        const sessions = JSON.parse(localStorage.getItem("regnav:sessions") || "[]");
-        const s = sessions.find((ss: any) => ss.id === sessionId);
-        if (s) setSelected(s);
-      } catch {
-        setSelected(null);
-      }
+      void loadSessionDetail(sessionId);
     }
-  }, [location.search]);
+  }, [location.search, loadSessionDetail, userId]);
+
+  const handleSessionSelect = useCallback(
+    (sessionId: string | null) => {
+      if (!sessionId) {
+        setSelectedSession(null);
+        return;
+      }
+      void loadSessionDetail(sessionId);
+    },
+    [loadSessionDetail],
+  );
+
+  const handleSessionUpdated = useCallback(
+    async (sessionId: string) => {
+      await loadSessions();
+      if (sessionId) {
+        await loadSessionDetail(sessionId);
+      }
+    },
+    [loadSessions, loadSessionDetail],
+  );
+
+  const handleSessionCreated = useCallback(
+    async (sessionId: string) => {
+      await loadSessions();
+      await loadSessionDetail(sessionId);
+    },
+    [loadSessions, loadSessionDetail],
+  );
+
+  const handleDeleteSession = useCallback(
+    async (sessionId: string) => {
+      if (!userId) return;
+      try {
+        const res = await fetch(`/api/chat/sessions/${encodeURIComponent(sessionId)}`, {
+          method: "DELETE",
+          headers,
+        });
+        if (!res.ok) {
+          const { error } = (await res.json()) as { error?: string };
+          throw new Error(error ?? `Failed to delete session (${res.status})`);
+        }
+        toast({ title: "Deleted", description: "Chat removed." });
+        if (selectedSession?.id === sessionId) {
+          setSelectedSession(null);
+        }
+        await loadSessions();
+      } catch (error) {
+        const description = error instanceof Error ? error.message : "Could not delete session.";
+        toast({ title: "Error", description });
+      }
+    },
+    [headers, loadSessions, selectedSession?.id, userId],
+  );
+
+  const resetSession = useCallback(() => {
+    setSelectedSession(null);
+  }, []);
 
   return (
     <div className="min-h-screen bg-background">
@@ -32,14 +148,33 @@ export default function Chat() {
       <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
         <section className="grid grid-cols-1 gap-6 md:grid-cols-12">
           <aside className="md:col-span-4">
-            <div className="rounded-2xl border bg-card p-4">
-              <ChatHistory onSelect={(s) => setSelected(s)} />
+            <div className="space-y-4">
+              <div className="rounded-2xl border bg-card p-4">
+                <ChatHistory
+                  sessions={sessions}
+                  loading={sessionsLoading}
+                  onSelect={handleSessionSelect}
+                  onDelete={handleDeleteSession}
+                />
+              </div>
+              <div className="rounded-2xl border bg-card p-4">
+                <FiltersPanel value={filters} onChange={setFilters} onReset={() => setFilters(createDefaultSearchFilters())} />
+              </div>
             </div>
           </aside>
 
           <div className="md:col-span-8">
             <div className="rounded-2xl border bg-card p-4">
-              <ChatPanel key={selected?.id || "new"} filters={filters} initialMessages={selected?.messages} />
+              <ChatPanel
+                key={selectedSession?.id || "new"}
+                filters={filters}
+                userId={userId}
+                session={selectedSession}
+                loading={chatLoading}
+                onSessionCreated={handleSessionCreated}
+                onSessionUpdated={handleSessionUpdated}
+                onResetSession={resetSession}
+              />
             </div>
           </div>
         </section>

--- a/Frontend/client/pages/Index.tsx
+++ b/Frontend/client/pages/Index.tsx
@@ -3,21 +3,30 @@ import { SiteHeader } from "@/components/layout/SiteHeader";
 import { SiteFooter } from "@/components/layout/SiteFooter";
 import { ChatPanel } from "@/components/regnav/ChatPanel";
 import { SourcesPanel } from "@/components/regnav/SourcesPanel";
+import { FiltersPanel } from "@/components/regnav/FiltersPanel";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
-import { SearchFilters, ScoredDoc } from "@shared/api";
+import { SearchFilters, ChatCitation } from "@shared/api";
+import { createDefaultSearchFilters } from "@/lib/searchFilters";
+import { ensureUserId } from "@/lib/user";
 
 export default function Index() {
-  const [filters, setFilters] = useState<SearchFilters>({ jurisdiction: "Maryland" });
-  const [latestHits, setLatestHits] = useState<ScoredDoc[]>([]);
+  const [filters, setFilters] = useState<SearchFilters>(() => createDefaultSearchFilters());
+  const [latestHits, setLatestHits] = useState<ChatCitation[]>([]);
+  const [userId, setUserId] = useState<string>("");
 
   useEffect(() => {
     const handler = (e: Event) => {
-      const ce = e as CustomEvent<ScoredDoc[]>;
+      const ce = e as CustomEvent<ChatCitation[]>;
       setLatestHits(ce.detail || []);
     };
     window.addEventListener("regnav:citations", handler as EventListener);
     return () => window.removeEventListener("regnav:citations", handler as EventListener);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setUserId(ensureUserId());
   }, []);
 
   return (
@@ -54,12 +63,17 @@ export default function Index() {
         <section id="workspace" className="grid grid-cols-1 gap-6 md:grid-cols-12">
           <div className="md:col-span-8">
             <div className="rounded-2xl border bg-card p-4">
-              <ChatPanel filters={filters} />
+              <ChatPanel filters={filters} userId={userId} session={null} />
             </div>
           </div>
           <aside className="md:col-span-4">
-            <div className="rounded-2xl border bg-card p-4">
-              <SourcesPanel latestHits={latestHits} />
+            <div className="space-y-4">
+              <div className="rounded-2xl border bg-card p-4">
+                <FiltersPanel value={filters} onChange={setFilters} onReset={() => setFilters(createDefaultSearchFilters())} />
+              </div>
+              <div className="rounded-2xl border bg-card p-4">
+                <SourcesPanel latestHits={latestHits} />
+              </div>
             </div>
           </aside>
         </section>

--- a/Frontend/server/index.ts
+++ b/Frontend/server/index.ts
@@ -4,6 +4,16 @@ import cors from "cors";
 import { handleDemo } from "./routes/demo";
 import { searchRoute } from "./routes/search";
 import { addDocumentRoute, listDocumentsRoute } from "./routes/documents";
+import {
+  addMemoryRoute,
+  createSessionRoute,
+  deleteMemoryRoute,
+  deleteSessionRoute,
+  getSessionRoute,
+  listMemoriesRoute,
+  listSessionsRoute,
+  renameSessionRoute,
+} from "./routes/chat";
 
 export function createServer() {
   const app = express();
@@ -25,6 +35,14 @@ export function createServer() {
   app.post("/api/search", searchRoute);
   app.get("/api/documents", listDocumentsRoute);
   app.post("/api/documents", addDocumentRoute);
+  app.get("/api/chat/sessions", listSessionsRoute);
+  app.post("/api/chat/sessions", createSessionRoute);
+  app.get("/api/chat/sessions/:sessionId", getSessionRoute);
+  app.patch("/api/chat/sessions/:sessionId", renameSessionRoute);
+  app.delete("/api/chat/sessions/:sessionId", deleteSessionRoute);
+  app.get("/api/chat/memories", listMemoriesRoute);
+  app.post("/api/chat/memories", addMemoryRoute);
+  app.delete("/api/chat/memories/:memoryId", deleteMemoryRoute);
 
   return app;
 }

--- a/Frontend/server/node-build.ts
+++ b/Frontend/server/node-build.ts
@@ -1,22 +1,22 @@
 import path from "path";
+import { fileURLToPath } from "url";
+import express from "express";
 import { createServer } from "./index";
-import * as express from "express";
 
 const app = createServer();
-const port = process.env.PORT || 3000;
+const port = Number(process.env.PORT) || 3000;
 
 // In production, serve the built SPA files
-const __dirname = import.meta.dirname;
-const distPath = path.join(__dirname, "../spa");
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distPath = path.resolve(__dirname, "../spa");
 
-// Serve static files
+// Serve static assets from the built client bundle
 app.use(express.static(distPath));
 
-// Handle React Router - serve index.html for all non-API routes
-app.get("*", (req, res) => {
-  // Don't serve index.html for API routes
-  if (req.path.startsWith("/api/") || req.path.startsWith("/health")) {
-    return res.status(404).json({ error: "API endpoint not found" });
+// Handle React Router - serve index.html for non-API GET requests
+app.use((req, res, next) => {
+  if (req.method !== "GET" || req.path.startsWith("/api/") || req.path.startsWith("/health")) {
+    return next();
   }
 
   res.sendFile(path.join(distPath, "index.html"));

--- a/Frontend/server/routes/chat.ts
+++ b/Frontend/server/routes/chat.ts
@@ -1,0 +1,141 @@
+import { RequestHandler } from "express";
+import {
+  addMemory,
+  createSession,
+  getSession,
+  listMemories,
+  listSessions,
+  removeMemory,
+  removeSession,
+  renameSession,
+} from "../services/backend";
+
+function requireUserId(req: Parameters<RequestHandler>[0], res: Parameters<RequestHandler>[1]): string | undefined {
+  const userId = req.header("x-user-id");
+  if (!userId) {
+    res.status(400).json({ error: "Missing X-User-Id header" });
+    return undefined;
+  }
+  return userId;
+}
+
+export const listSessionsRoute: RequestHandler = async (req, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const sessions = await listSessions(userId);
+    res.status(200).json({ sessions });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Backend error";
+    res.status(502).json({ error: message });
+  }
+};
+
+export const getSessionRoute: RequestHandler = async (req, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const { sessionId } = req.params;
+  if (!sessionId) {
+    return res.status(400).json({ error: "Missing sessionId parameter" });
+  }
+  try {
+    const session = await getSession(userId, sessionId);
+    res.status(200).json({ session });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Backend error";
+    res.status(message.includes("not found") ? 404 : 502).json({ error: message });
+  }
+};
+
+export const createSessionRoute: RequestHandler = async (req, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const title = typeof req.body?.title === "string" ? req.body.title : undefined;
+  try {
+    const session = await createSession(userId, title);
+    res.status(201).json({ session });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Backend error";
+    res.status(502).json({ error: message });
+  }
+};
+
+export const renameSessionRoute: RequestHandler = async (req, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const { sessionId } = req.params;
+  const title = typeof req.body?.title === "string" ? req.body.title : "";
+  if (!sessionId) {
+    return res.status(400).json({ error: "Missing sessionId parameter" });
+  }
+  if (!title.trim()) {
+    return res.status(400).json({ error: "Title must not be empty" });
+  }
+  try {
+    const session = await renameSession(userId, sessionId, title);
+    res.status(200).json({ session });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Backend error";
+    res.status(message.includes("not found") ? 404 : 502).json({ error: message });
+  }
+};
+
+export const deleteSessionRoute: RequestHandler = async (req, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const { sessionId } = req.params;
+  if (!sessionId) {
+    return res.status(400).json({ error: "Missing sessionId parameter" });
+  }
+  try {
+    await removeSession(userId, sessionId);
+    res.status(204).send();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Backend error";
+    res.status(message.includes("not found") ? 404 : 502).json({ error: message });
+  }
+};
+
+export const listMemoriesRoute: RequestHandler = async (req, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const memories = await listMemories(userId);
+    res.status(200).json({ memories });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Backend error";
+    res.status(502).json({ error: message });
+  }
+};
+
+export const addMemoryRoute: RequestHandler = async (req, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const content = typeof req.body?.content === "string" ? req.body.content : "";
+  if (!content.trim()) {
+    return res.status(400).json({ error: "Memory content must not be empty" });
+  }
+  try {
+    const memory = await addMemory(userId, content);
+    res.status(201).json({ memory });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Backend error";
+    res.status(502).json({ error: message });
+  }
+};
+
+export const deleteMemoryRoute: RequestHandler = async (req, res) => {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const { memoryId } = req.params;
+  if (!memoryId) {
+    return res.status(400).json({ error: "Missing memoryId parameter" });
+  }
+  try {
+    await removeMemory(userId, memoryId);
+    res.status(204).send();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Backend error";
+    res.status(message.includes("not found") ? 404 : 502).json({ error: message });
+  }
+};

--- a/Frontend/server/routes/search.ts
+++ b/Frontend/server/routes/search.ts
@@ -1,12 +1,23 @@
 import { RequestHandler } from "express";
-import { SearchRequest, SearchResponse } from "@shared/api";
-import { handleSearch } from "../services/search";
+import { ChatAskRequest } from "@shared/api";
+import { askBackend } from "../services/backend";
 
-export const searchRoute: RequestHandler = (req, res) => {
-  const body = req.body as SearchRequest;
-  if (!body || typeof body.query !== "string" || body.query.trim().length === 0) {
-    return res.status(400).json({ error: "Missing 'query'" });
+export const searchRoute: RequestHandler = async (req, res) => {
+  const userId = req.header("x-user-id");
+  if (!userId) {
+    return res.status(400).json({ error: "Missing X-User-Id header" });
   }
-  const response: SearchResponse = handleSearch(body);
-  res.status(200).json(response);
+
+  const body = req.body as ChatAskRequest;
+  if (!body || typeof body.question !== "string" || body.question.trim().length === 0) {
+    return res.status(400).json({ error: "Missing 'question'" });
+  }
+
+  try {
+    const response = await askBackend(userId, body);
+    res.status(200).json(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Backend error";
+    res.status(502).json({ error: message });
+  }
 };

--- a/Frontend/server/services/backend.ts
+++ b/Frontend/server/services/backend.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from "crypto";
+import {
+  ChatAskRequest,
+  ChatAskResponse,
+  ChatMemory,
+  ChatMemoryResponse,
+  ChatSessionCreateResponse,
+  ChatSessionDetail,
+  ChatSessionResponse,
+  ChatSessionSummary,
+  ListMemoriesResponse,
+  ListSessionsResponse,
+} from "@shared/api";
+
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://127.0.0.1:8000";
+
+async function backendFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const url = new URL(path, BACKEND_URL).toString();
+  const headers: HeadersInit = {
+    Accept: "application/json",
+    ...(init.headers ?? {}),
+  };
+  const res = await fetch(url, { ...init, headers });
+  if (!res.ok) {
+    let detail = `Backend request failed with status ${res.status}`;
+    try {
+      const body = (await res.json()) as { detail?: string };
+      if (body && typeof body.detail === "string") {
+        detail = body.detail;
+      }
+    } catch {
+      // ignore JSON parsing errors
+    }
+    throw new Error(detail);
+  }
+  return (await res.json()) as T;
+}
+
+function mapCitation(raw: any) {
+  return {
+    id: raw.id ?? raw.doc_id ?? raw.comar_number ?? randomUUID(),
+    label: raw.label,
+    pages: raw.pages,
+    url: raw.url,
+    docId: raw.doc_id,
+    docTitle: raw.doc_title,
+    comarNumber: raw.comar_number,
+    comarDisplay: raw.comar_display,
+    snippet: raw.snippet,
+  };
+}
+
+function mapSessionSummary(raw: any): ChatSessionSummary {
+  return {
+    id: raw.id,
+    title: raw.title,
+    snippet: raw.snippet ?? null,
+    createdAt: raw.createdAt ?? raw.created_at,
+    updatedAt: raw.updatedAt ?? raw.updated_at,
+  };
+}
+
+function mapMessage(raw: any) {
+  return {
+    id: raw.id,
+    role: raw.role,
+    content: raw.content,
+    createdAt: raw.createdAt ?? raw.created_at,
+    citations: Array.isArray(raw.citations) ? raw.citations.map(mapCitation) : undefined,
+  };
+}
+
+export async function askBackend(userId: string, payload: ChatAskRequest): Promise<ChatAskResponse> {
+  const body = {
+    question: payload.question,
+    k: payload.topK ?? 5,
+    user_id: userId,
+    session_id: payload.sessionId,
+    session_title: payload.sessionTitle,
+    filters: payload.filters,
+  };
+  const raw = await backendFetch<any>("/ask", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return {
+    answer: raw.answer,
+    sources: Array.isArray(raw.sources) ? raw.sources.map(mapCitation) : [],
+    sessionId: raw.session_id ?? raw.sessionId,
+    userMessage: mapMessage(raw.user_message ?? raw.userMessage),
+    assistantMessage: mapMessage(raw.assistant_message ?? raw.assistantMessage),
+    session: mapSessionSummary(raw.session),
+  };
+}
+
+export async function listSessions(userId: string): Promise<ChatSessionSummary[]> {
+  const data = await backendFetch<ListSessionsResponse>(`/users/${encodeURIComponent(userId)}/sessions`);
+  return Array.isArray(data.sessions) ? data.sessions.map(mapSessionSummary) : [];
+}
+
+export async function getSession(userId: string, sessionId: string): Promise<ChatSessionDetail> {
+  const data = await backendFetch<ChatSessionResponse>(
+    `/users/${encodeURIComponent(userId)}/sessions/${encodeURIComponent(sessionId)}`,
+  );
+  const session = data.session;
+  return {
+    ...mapSessionSummary(session),
+    messages: Array.isArray(session.messages) ? session.messages.map(mapMessage) : [],
+  };
+}
+
+export async function createSession(userId: string, title?: string): Promise<ChatSessionSummary> {
+  const data = await backendFetch<ChatSessionCreateResponse>(`/users/${encodeURIComponent(userId)}/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ title }),
+  });
+  return mapSessionSummary(data.session);
+}
+
+export async function renameSession(userId: string, sessionId: string, title: string): Promise<ChatSessionSummary> {
+  const data = await backendFetch<ChatSessionCreateResponse>(
+    `/users/${encodeURIComponent(userId)}/sessions/${encodeURIComponent(sessionId)}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title }),
+    },
+  );
+  return mapSessionSummary(data.session);
+}
+
+export async function removeSession(userId: string, sessionId: string): Promise<void> {
+  await backendFetch(`/users/${encodeURIComponent(userId)}/sessions/${encodeURIComponent(sessionId)}`, {
+    method: "DELETE",
+  });
+}
+
+export async function listMemories(userId: string): Promise<ChatMemory[]> {
+  const data = await backendFetch<ListMemoriesResponse>(`/users/${encodeURIComponent(userId)}/memories`);
+  return Array.isArray(data.memories)
+    ? data.memories.map((m) => ({
+        id: m.id,
+        content: m.content,
+        createdAt: m.createdAt ?? (m as any).created_at,
+        updatedAt: m.updatedAt ?? (m as any).updated_at,
+      }))
+    : [];
+}
+
+export async function addMemory(userId: string, content: string): Promise<ChatMemory> {
+  const data = await backendFetch<ChatMemoryResponse>(`/users/${encodeURIComponent(userId)}/memories`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content }),
+  });
+  const m = data.memory;
+  return {
+    id: m.id,
+    content: m.content,
+    createdAt: m.createdAt ?? (m as any).created_at,
+    updatedAt: m.updatedAt ?? (m as any).updated_at,
+  };
+}
+
+export async function removeMemory(userId: string, memoryId: string): Promise<void> {
+  await backendFetch(`/users/${encodeURIComponent(userId)}/memories/${encodeURIComponent(memoryId)}`, {
+    method: "DELETE",
+  });
+}

--- a/Frontend/server/services/search.ts
+++ b/Frontend/server/services/search.ts
@@ -1,4 +1,4 @@
-import { AddDocumentRequest, RegDocument, RegDocumentMeta, ScoredDoc, SearchFilters, SearchRequest, SearchResponse } from "@shared/api";
+import { AddDocumentRequest, RegDocument, RegDocumentMeta } from "@shared/api";
 import { seedCorpus } from "../data/corpus";
 
 let documents: RegDocument[] = [...seedCorpus];
@@ -10,128 +10,10 @@ export function listDocuments(): RegDocumentMeta[] {
 export function addDocument(doc: AddDocumentRequest): RegDocumentMeta {
   const exists = documents.find((d) => d.id === doc.id);
   if (exists) {
-    // Replace existing document
     documents = documents.map((d) => (d.id === doc.id ? { ...doc } : d));
   } else {
     documents.push({ ...doc });
   }
   const { text, ...meta } = doc;
   return meta;
-}
-
-const tokenizer = (s: string): string[] =>
-  s
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, " ")
-    .split(/\s+/)
-    .filter(Boolean);
-
-function applyFilters(docs: RegDocument[], f?: SearchFilters): RegDocument[] {
-  if (!f) return docs;
-  return docs.filter((d) => {
-    if (f.jurisdiction && d.jurisdiction !== f.jurisdiction) return false;
-    if (f.agency && d.agency.toLowerCase().indexOf(f.agency.toLowerCase()) === -1) return false;
-    if (typeof f.yearFrom === "number" && d.year < f.yearFrom) return false;
-    if (typeof f.yearTo === "number" && d.year > f.yearTo) return false;
-    return true;
-  });
-}
-
-function computeTfIdfScores(query: string, docs: RegDocument[]): { doc: RegDocument; score: number; highlights: string[] }[] {
-  const qTokens = Array.from(new Set(tokenizer(query)));
-  if (qTokens.length === 0) return docs.map((doc) => ({ doc, score: 0, highlights: [] }));
-
-  // Document frequencies
-  const df = new Map<string, number>();
-  for (const t of qTokens) df.set(t, 0);
-  const docTokens: Map<string, number>[] = [];
-
-  for (const d of docs) {
-    const tokens = tokenizer(d.text);
-    const counts = new Map<string, number>();
-    for (const t of tokens) {
-      if (!counts.has(t)) counts.set(t, 0);
-      counts.set(t, (counts.get(t) || 0) + 1);
-    }
-    docTokens.push(counts);
-    for (const t of qTokens) {
-      if (counts.has(t)) df.set(t, (df.get(t) || 0) + 1);
-    }
-  }
-
-  const N = docs.length;
-  return docs.map((doc, i) => {
-    const counts = docTokens[i];
-    let score = 0;
-    for (const t of qTokens) {
-      const tf = counts.get(t) || 0;
-      const idf = Math.log((N + 1) / ((df.get(t) || 0) + 1)) + 1; // smoothed
-      score += tf * idf;
-    }
-    return { doc, score, highlights: qTokens.filter((t) => (counts.get(t) || 0) > 0) };
-  });
-}
-
-function bestSnippet(text: string, terms: string[], windowSize = 240): { text: string; start: number; end: number } {
-  if (terms.length === 0) return { text: text.slice(0, windowSize), start: 0, end: Math.min(windowSize, text.length) };
-  const lower = text.toLowerCase();
-  let bestStart = 0;
-  let bestEnd = Math.min(windowSize, text.length);
-  let bestHits = -1;
-  for (let i = 0; i < lower.length; i += Math.max(20, Math.floor(windowSize / 4))) {
-    const start = Math.max(0, i - Math.floor(windowSize / 2));
-    const end = Math.min(text.length, start + windowSize);
-    const chunk = lower.slice(start, end);
-    const hits = terms.reduce((acc, t) => acc + (chunk.indexOf(t) >= 0 ? 1 : 0), 0);
-    if (hits > bestHits) {
-      bestHits = hits;
-      bestStart = start;
-      bestEnd = end;
-    }
-  }
-  const snippet = (bestStart > 0 ? "…" : "") + text.slice(bestStart, bestEnd) + (bestEnd < text.length ? "…" : "");
-  return { text: snippet, start: bestStart, end: bestEnd };
-}
-
-function synthesizeAnswer(scored: { doc: RegDocument; score: number; highlights: string[] }[], topK: number, query: string): string {
-  const top = scored
-    .sort((a, b) => b.score - a.score)
-    .slice(0, topK)
-    .map(({ doc }) => doc);
-
-  if (top.length === 0) {
-    return `No matching regulations found for "${query}" in the current corpus.`;
-  }
-
-  const bullets = top
-    .map((d, idx) => {
-      const summary = d.text.replace(/\s+/g, " ").slice(0, 220);
-      return `${idx + 1}. ${d.title} — ${summary}${summary.length >= 220 ? "…" : ""}`;
-    })
-    .join("\n");
-
-  return `Here is what the corpus says about "${query}":\n\n${bullets}\n\nCite the sources listed above in your reporting. Use filters to narrow jurisdiction/agency.`;
-}
-
-export function handleSearch(req: SearchRequest): SearchResponse {
-  const topK = req.topK ?? 5;
-  const filtered = applyFilters(documents, req.filters);
-  const scored = computeTfIdfScores(req.query, filtered);
-  const answer = synthesizeAnswer(scored, Math.min(topK, 5), req.query);
-
-  const hits: ScoredDoc[] = scored
-    .sort((a, b) => b.score - a.score)
-    .slice(0, topK)
-    .map(({ doc, score, highlights }) => {
-      const { text, ...meta } = doc;
-      const snippet = bestSnippet(text, highlights);
-      return {
-        meta,
-        score,
-        snippet,
-        highlights,
-      };
-    });
-
-  return { answer, hits };
 }

--- a/Frontend/shared/api.ts
+++ b/Frontend/shared/api.ts
@@ -33,35 +33,6 @@ export interface SearchFilters {
   section?: string; // e.g., 15.20.13.02
 }
 
-export interface SearchRequest {
-  query: string;
-  filters?: SearchFilters;
-  topK?: number;
-}
-
-export interface Snippet {
-  text: string;
-  start: number;
-  end: number;
-}
-
-export interface ScoredDoc {
-  meta: RegDocumentMeta;
-  score: number;
-  snippet: Snippet;
-  highlights: string[]; // matched terms
-}
-
-export interface SearchResponse {
-  answer: string; // deterministic synthesis from top matches
-  hits: ScoredDoc[];
-  tokenUsage?: {
-    // reserved for future LLM integration
-    inputTokens?: number;
-    outputTokens?: number;
-  };
-}
-
 export interface ListDocumentsResponse {
   documents: RegDocumentMeta[];
 }
@@ -73,4 +44,82 @@ export interface AddDocumentRequest extends RegDocumentMeta {
 export interface AddDocumentResponse {
   ok: true;
   document: RegDocumentMeta;
+}
+
+export interface ChatCitation {
+  id: string;
+  label: string;
+  pages: string;
+  url?: string;
+  docId?: string;
+  docTitle?: string;
+  comarNumber?: string;
+  comarDisplay?: string;
+  snippet?: string;
+}
+
+export type ChatRole = "user" | "assistant";
+
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  content: string;
+  createdAt: string;
+  citations?: ChatCitation[];
+}
+
+export interface ChatSessionSummary {
+  id: string;
+  title: string;
+  snippet?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChatSessionDetail extends ChatSessionSummary {
+  messages: ChatMessage[];
+}
+
+export interface ChatAskRequest {
+  question: string;
+  filters?: SearchFilters;
+  topK?: number;
+  sessionId?: string;
+  sessionTitle?: string;
+}
+
+export interface ChatAskResponse {
+  answer: string;
+  sources: ChatCitation[];
+  sessionId: string;
+  userMessage: ChatMessage;
+  assistantMessage: ChatMessage;
+  session: ChatSessionSummary;
+}
+
+export interface ListSessionsResponse {
+  sessions: ChatSessionSummary[];
+}
+
+export interface ChatSessionResponse {
+  session: ChatSessionDetail;
+}
+
+export interface ChatSessionCreateResponse {
+  session: ChatSessionSummary;
+}
+
+export interface ChatMemory {
+  id: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListMemoriesResponse {
+  memories: ChatMemory[];
+}
+
+export interface ChatMemoryResponse {
+  memory: ChatMemory;
 }

--- a/backend/app/chat_store.py
+++ b/backend/app/chat_store.py
@@ -1,0 +1,296 @@
+"""Persistence layer for chat sessions and user memories."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+from uuid import uuid4
+
+
+def _utcnow() -> str:
+    """Return an ISO-8601 timestamp in UTC."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _summarize(text: str, limit: int = 140) -> str:
+    """Return a short snippet suitable for previews."""
+
+    snippet = " ".join(text.strip().split())
+    if len(snippet) <= limit:
+        return snippet
+    return snippet[: limit - 1] + "…"
+
+
+@dataclass
+class ChatMessageRecord:
+    """Representation of a single chat message."""
+
+    id: str
+    role: str
+    content: str
+    created_at: str
+    citations: Optional[List[Dict[str, object]]] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        data: Dict[str, object] = {
+            "id": self.id,
+            "role": self.role,
+            "content": self.content,
+            "createdAt": self.created_at,
+        }
+        if self.citations:
+            data["citations"] = self.citations
+        return data
+
+
+class ChatStore:
+    """SQLite-backed persistence for chat sessions and user memories."""
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        # Initialise schema
+        with self._get_conn() as conn:
+            conn.executescript(
+                """
+                PRAGMA journal_mode=WAL;
+                PRAGMA foreign_keys=ON;
+
+                CREATE TABLE IF NOT EXISTS users (
+                    id TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    title TEXT NOT NULL,
+                    snippet TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS messages (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                    role TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
+                    content TEXT NOT NULL,
+                    citations TEXT,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS memories (
+                    id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    content TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                """
+            )
+
+    @contextmanager
+    def _get_conn(self) -> Iterable[sqlite3.Connection]:
+        conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    # -- user helpers -----------------------------------------------------
+
+    def ensure_user(self, user_id: str) -> None:
+        ts = _utcnow()
+        with self._get_conn() as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO users (id, created_at) VALUES (?, ?)",
+                (user_id, ts),
+            )
+
+    # -- session helpers --------------------------------------------------
+
+    def _session_summary_from_row(self, row: sqlite3.Row) -> Dict[str, object]:
+        return {
+            "id": row["id"],
+            "title": row["title"],
+            "snippet": row["snippet"],
+            "createdAt": row["created_at"],
+            "updatedAt": row["updated_at"],
+        }
+
+    def create_session(self, user_id: str, title: str) -> Dict[str, object]:
+        session_id = str(uuid4())
+        ts = _utcnow()
+        title = title.strip() or "New chat"
+        with self._get_conn() as conn:
+            conn.execute(
+                "INSERT INTO sessions (id, user_id, title, snippet, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (session_id, user_id, title, None, ts, ts),
+            )
+            row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+        if row is None:
+            raise RuntimeError("Failed to create session")
+        return self._session_summary_from_row(row)
+
+    def rename_session(self, user_id: str, session_id: str, title: str) -> Dict[str, object]:
+        title = title.strip()
+        if not title:
+            raise ValueError("title must not be empty")
+        ts = _utcnow()
+        with self._get_conn() as conn:
+            res = conn.execute(
+                "UPDATE sessions SET title = ?, updated_at = ? WHERE id = ? AND user_id = ?",
+                (title, ts, session_id, user_id),
+            )
+            if res.rowcount == 0:
+                raise KeyError("session not found")
+            row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+        if row is None:
+            raise KeyError("session not found")
+        return self._session_summary_from_row(row)
+
+    def delete_session(self, user_id: str, session_id: str) -> None:
+        with self._get_conn() as conn:
+            res = conn.execute("DELETE FROM sessions WHERE id = ? AND user_id = ?", (session_id, user_id))
+            if res.rowcount == 0:
+                raise KeyError("session not found")
+
+    def list_sessions(self, user_id: str) -> List[Dict[str, object]]:
+        with self._get_conn() as conn:
+            rows = conn.execute(
+                "SELECT * FROM sessions WHERE user_id = ? ORDER BY updated_at DESC",
+                (user_id,),
+            ).fetchall()
+        return [self._session_summary_from_row(r) for r in rows]
+
+    def get_session(self, user_id: str, session_id: str) -> Dict[str, object]:
+        with self._get_conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE id = ? AND user_id = ?",
+                (session_id, user_id),
+            ).fetchone()
+            if row is None:
+                raise KeyError("session not found")
+            messages = conn.execute(
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY created_at ASC",
+                (session_id,),
+            ).fetchall()
+        session = self._session_summary_from_row(row)
+        session["messages"] = [self._message_from_row(m).to_dict() for m in messages]
+        return session
+
+    def _message_from_row(self, row: sqlite3.Row) -> ChatMessageRecord:
+        citations_json = row["citations"]
+        citations: Optional[List[Dict[str, object]]]
+        if citations_json:
+            citations = json.loads(citations_json)
+        else:
+            citations = None
+        return ChatMessageRecord(
+            id=row["id"],
+            role=row["role"],
+            content=row["content"],
+            created_at=row["created_at"],
+            citations=citations,
+        )
+
+    def append_message(
+        self,
+        session_id: str,
+        role: str,
+        content: str,
+        citations: Optional[List[Dict[str, object]]] = None,
+    ) -> ChatMessageRecord:
+        if role not in {"user", "assistant"}:
+            raise ValueError("role must be 'user' or 'assistant'")
+        msg_id = str(uuid4())
+        ts = _utcnow()
+        citations_json = json.dumps(citations or []) if citations else None
+        with self._get_conn() as conn:
+            res = conn.execute(
+                "INSERT INTO messages (id, session_id, role, content, citations, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (msg_id, session_id, role, content, citations_json, ts),
+            )
+            if res.rowcount == 0:
+                raise KeyError("session not found")
+            snippet = None
+            if role == "assistant":
+                snippet = _summarize(content)
+            conn.execute(
+                "UPDATE sessions SET updated_at = ?, snippet = COALESCE(?, snippet) WHERE id = ?",
+                (ts, snippet, session_id),
+            )
+            row = conn.execute("SELECT * FROM messages WHERE id = ?", (msg_id,)).fetchone()
+        if row is None:
+            raise RuntimeError("failed to store message")
+        return self._message_from_row(row)
+
+    def get_recent_messages(self, session_id: str, limit: int = 6) -> List[Dict[str, object]]:
+        with self._get_conn() as conn:
+            rows = conn.execute(
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY created_at DESC LIMIT ?",
+                (session_id, limit),
+            ).fetchall()
+        return [self._message_from_row(r).to_dict() for r in reversed(rows)]
+
+    # -- memory helpers ---------------------------------------------------
+
+    def list_memories(self, user_id: str) -> List[Dict[str, object]]:
+        with self._get_conn() as conn:
+            rows = conn.execute(
+                "SELECT * FROM memories WHERE user_id = ? ORDER BY updated_at DESC",
+                (user_id,),
+            ).fetchall()
+        memories: List[Dict[str, object]] = []
+        for r in rows:
+            memories.append(
+                {
+                    "id": r["id"],
+                    "content": r["content"],
+                    "createdAt": r["created_at"],
+                    "updatedAt": r["updated_at"],
+                }
+            )
+        return memories
+
+    def add_memory(self, user_id: str, content: str) -> Dict[str, object]:
+        content = content.strip()
+        if not content:
+            raise ValueError("content must not be empty")
+        mem_id = str(uuid4())
+        ts = _utcnow()
+        with self._get_conn() as conn:
+            conn.execute(
+                "INSERT INTO memories (id, user_id, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+                (mem_id, user_id, content, ts, ts),
+            )
+            row = conn.execute("SELECT * FROM memories WHERE id = ?", (mem_id,)).fetchone()
+        if row is None:
+            raise RuntimeError("failed to create memory")
+        return {
+            "id": row["id"],
+            "content": row["content"],
+            "createdAt": row["created_at"],
+            "updatedAt": row["updated_at"],
+        }
+
+    def delete_memory(self, user_id: str, memory_id: str) -> None:
+        with self._get_conn() as conn:
+            res = conn.execute(
+                "DELETE FROM memories WHERE id = ? AND user_id = ?",
+                (memory_id, user_id),
+            )
+            if res.rowcount == 0:
+                raise KeyError("memory not found")
+
+    def get_memory_text(self, user_id: str) -> List[str]:
+        return [m["content"] for m in self.list_memories(user_id)]
+


### PR DESCRIPTION
## Summary
- add a SQLite-backed chat store with REST endpoints for sessions, messages, and user memories and enrich RAG answers with citations and conversation context
- connect the Node proxy to the FastAPI backend and expose chat and memory APIs to the client
- update the React chat, history, and admin pages to use persisted sessions, store a stable user id, and surface backend citations

## Testing
- python -m compileall backend/app
- pnpm test
- pnpm typecheck
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cba613a464833199a64bd85b66b454